### PR TITLE
Fixes for mariadb-galera-server and nova_wsgi on upgrade Pike to Queens

### DIFF
--- a/docker/services/nova-api.yaml
+++ b/docker/services/nova-api.yaml
@@ -358,6 +358,7 @@ outputs:
               when:
                 - nova_api_httpd_enabled|bool
                 - httpd_running|bool
+              ignore_errors: True
             - name: Ensure all online data migrations for Nova have been applied
               shell: |
                 if {{ container_cli }} ps | grep nova_api; then

--- a/docker/services/pacemaker/database/mysql.yaml
+++ b/docker/services/pacemaker/database/mysql.yaml
@@ -473,7 +473,7 @@ outputs:
             # guarantee that ownership is fixed at the end of step 3
             - name: Update host mariadb packages
               when: step|int == 3
-              package: name=mariadb-server-galera state=latest
+              package: name=mariadb-galera-server state=latest
             - name: Mysql upgrade script
               set_fact:
                 mysql_upgrade_script:


### PR DESCRIPTION
Fixes for mariadb-galera-server and nova_wsgi on upgrade Pike to Queens.
Before changing these our upgrade was failing at these steps.